### PR TITLE
refactor: consolidate duplicate report generation logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,10 @@ cp settings.json.example settings.json
 docker build -t wordcount-bot .
 
 # Run once with environment variables
-docker run --rm -e BOT_USER=YourBot -e BOT_PASSWORD=secret wordcount-bot
+docker run --rm -e BOT_USER=YourBot -e BOT_PASSWORD=secret wordcount-bot --once
 
 # Run continuously
-docker run --rm -e BOT_USER=YourBot -e BOT_PASSWORD=secret wordcount-bot --
+docker run --rm -e BOT_USER=YourBot -e BOT_PASSWORD=secret wordcount-bot
 ```
 
 ## Architecture
@@ -80,4 +80,9 @@ docker run --rm -e BOT_USER=YourBot -e BOT_PASSWORD=secret wordcount-bot --
 ## Deployment Modes
 - **Local**: Direct Python execution with settings.json
 - **Docker**: Container with environment variable configuration
-- **Railway.app**: Automated cron deployment (every 5 minutes per railway.json)
+- **Railway.app**: Automated cron deployment (every 15 minutes per railway.json)
+
+## Testing and Quality
+- No automated test suite - manual testing via debug mode
+- No linting configuration - code follows Python 3.11+ standards
+- Dependencies: mwclient, mwparserfromhell, requests, beautifulsoup4


### PR DESCRIPTION
• Create ParsedData dataclass and collect_all_data() function to centralize data collection • Add *_from_data() variants that operate on shared parsed data instead of re-fetching • Update run_once() to collect data once and generate all three outputs, reducing API calls by ~66% • Maintain backward compatibility with original function signatures • Improve error handling with centralized exception management • Fix Docker command examples in CLAUDE.md documentation

🤖 Generated with [Claude Code](https://claude.ai/code)