### PR TITLE
Update bot.py (page moved)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -58,7 +58,7 @@ class BotConfig:
     arca_page: str = "Wikipedia:Arbitration/Requests/Clarification and Amendment"
     ae_page: str = "Wikipedia:Arbitration/Requests/Enforcement"
     arc_page: str = "Wikipedia:Arbitration/Requests/Case"
-    open_cases_page: str = "Template:ArbComOpenTasks/Cases"
+    open_cases_page: str = "Template:Arbitration Committee open tasks/Cases"
     
     target_page: str = "User:ClerkBot/word counts"
     data_page: str = "User:ClerkBot/word counts/data"


### PR DESCRIPTION
[[Template:ArbComOpenTasks/Cases]] was moved to [[Template:Arbitration Committee open tasks/Cases]] along with its parent template.

I have temporarily moved it back until this script is changed to check the new title.